### PR TITLE
fix: json is non parseable when object is used to define columns

### DIFF
--- a/src/Sqlx.ts
+++ b/src/Sqlx.ts
@@ -15,11 +15,15 @@ type FileSqlxConfig = SqlxConfig & {
           bigqueryPolicyTags?: string | string[];
         }
       | string;
-  };
+  } | Object;
 };
 
 const CONFIG_BLOCK_PATTERN =
   /config\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}/;
+
+// Matches expressions like `columns: object.property,`
+const COLUMN_OBJECT_DEFINITION_PATTERN =
+    /columns\s*:\s*[a-zA-Z_$][a-zA-Z_$0-9]*\.[a-zA-Z_$][a-zA-Z_$0-9]*\s*,?/g;
 
 class Sqlx {
   public filePath: string;
@@ -50,6 +54,7 @@ class Sqlx {
     try {
       const configContent = configMatch[0]
         .replace(/config\s*/, "")
+        .replace(COLUMN_OBJECT_DEFINITION_PATTERN, "");
       config = json5.parse(configContent);
     } catch (error) {
       throw new Error(`Failed to parse config in ${this.filePath}: ${error}`);

--- a/test/Sqlx.test.ts
+++ b/test/Sqlx.test.ts
@@ -20,6 +20,14 @@ describe("Sqlx", () => {
     }
   `;
 
+    let mockConfigContentWtObjectColumn = `
+    config {
+      type: "table",
+      columns: docs.column_description,
+    }
+  `;
+
+
   const mockDataformTable: DataformTable = {
     type: "table",
     target: {
@@ -122,6 +130,15 @@ describe("Sqlx", () => {
       (fs.readFileSync as jest.Mock).mockReturnValue("select 1");
       const sqlx = new Sqlx(mockFilePath, mockDataformTable);
       expect(sqlx["config"]).toHaveProperty("type");
+    });
+
+    it("column definition will be parsed as empty is declared as obj.key", () => {
+        (fs.readFileSync as jest.Mock).mockReturnValue(mockConfigContentWtObjectColumn);
+        const sqlx = new Sqlx(mockFilePath, mockDataformTable);
+        expect(fs.readFileSync).toHaveBeenCalledWith(mockFilePath, "utf-8");
+        expect(sqlx["config"].type).toBe("table");
+        expect(Object.keys(sqlx["config"].columns).length).toBe(0);
+        expect(JSON.stringify(sqlx["config"].columns)).toBe('{}');
     });
   });
 


### PR DESCRIPTION
solves: https://github.com/hiracky16/dataform-osmosis/issues/13

As a solution to the above I am replacing the javascript object declaration with empty string such that the remaining json is parsed by the json5 library. There might be a better solution / approach to handle this as the user has already specified the column definition in a separate file. But this will serve as a good starting point to try out the tool and get all the boilerplate columns across to the user for them to fill the column definiton in

**Testing**  

- [x] Added additional test to ensure the expected replacement behaviour when columns are defined as exported variables. 
- [x] `npm run test` passes   
- [x] [Link to verify the regex working](https://regex101.com/r/g2o5Ma/1), this could be written as a test :) 